### PR TITLE
HAMSTR-813 auto release on arbitrated release

### DIFF
--- a/src/ArbitrationModule.sol
+++ b/src/ArbitrationModule.sol
@@ -46,7 +46,7 @@ contract ArbitrationModule is IArbitrationModule
         return proposals[proposalId];
     }
 
-    function proposeArbitration(IPolyEscrow polyEscrow, bytes32 escrowId, ArbitrationType proposalType, uint256 amount) external virtual {
+    function proposeArbitration(IPolyEscrow polyEscrow, bytes32 escrowId, ArbitrationType proposalType, uint256 amount, bool autoExecute) external virtual {
 
         /*
         WHO can propose arbitration? 
@@ -74,6 +74,7 @@ contract ArbitrationModule is IArbitrationModule
         proposals[propId].amount = amount;
         proposals[propId].status = ArbitrationStatus.ACTIVE;
         proposals[propId].votesAgainst = 0;
+        proposals[propId].autoExecute = autoExecute;
 
         //TODO: validate the amount (should be realistic and related to amount in escrow)
 
@@ -121,6 +122,11 @@ contract ArbitrationModule is IArbitrationModule
         uint8 arbitersRequired = escrow.arbitersRequired;
         if (proposal.votesFor >= arbitersRequired) {
             proposal.status = ArbitrationStatus.ACCEPTED;
+            
+            // Auto-execute if autoExecute flag is true
+            if (proposal.autoExecute) {
+                _executeArbitration(polyEscrow, proposal);
+            }
         }
         else if (proposal.votesAgainst >= (arbiterCount - arbitersRequired)) {
             proposal.status = ArbitrationStatus.REJECTED;
@@ -128,8 +134,6 @@ contract ArbitrationModule is IArbitrationModule
 
         //raise event 
         emit VoteRecorded(proposal.id, proposal.escrowId, msg.sender);
-
-        //TODO: auto-execute?
     }
 
     function cancelArbitration(bytes32 proposalId) external virtual {
@@ -147,7 +151,7 @@ contract ArbitrationModule is IArbitrationModule
         proposal.status = ArbitrationStatus.CANCELED;
     }
 
-    function executeArbitration(IPolyEscrow polyEscrow, bytes32 proposalId) external virtual view {
+    function executeArbitration(IPolyEscrow polyEscrow, bytes32 proposalId) external virtual {
 
         //get the arbitration proposal
         ArbitrationProposal storage proposal = proposals[proposalId];
@@ -194,8 +198,10 @@ contract ArbitrationModule is IArbitrationModule
         return false;
     }
 
-    function _executeArbitration(IPolyEscrow /*polyEscrow*/, ArbitrationProposal storage /*proposal*/) internal pure {
-        revert("NotImplemented");
+    function _executeArbitration(IPolyEscrow polyEscrow, ArbitrationProposal storage proposal) internal {
+        polyEscrow.executeArbitrationProposal(proposal.escrowId, proposal.proposalType, proposal.amount);
+        proposal.status = ArbitrationStatus.EXECUTED;
+        emit ProposalExecuted(proposal.id, proposal.escrowId, msg.sender);
     }
 
     function _generateUniqueProposalId(IPolyEscrow polyEscrow, bytes32 escrowId) internal view returns (bytes32) {

--- a/src/PolyEscrow.sol
+++ b/src/PolyEscrow.sol
@@ -526,6 +526,19 @@ contract PolyEscrow is HasSecurityContext, Pausable, IPolyEscrow
     function _getEscrowAmountRemaining(Escrow memory escrow) internal pure returns (uint256) {
         return escrow.amountPaid - escrow.amountRefunded - escrow.amountReleased;
     }
+
+    function executeArbitrationProposal(bytes32 escrowId, ArbitrationType proposalType, uint256 amount) external {
+        Escrow storage escrow = escrows[escrowId];
+        require(escrow.id != bytes32(0), "InvalidEscrow");
+        
+        require(msg.sender == address(escrow.arbitrationModule), "Unauthorized");
+        
+        if (proposalType == ArbitrationType.REFUND) {
+            _refund(escrowId, amount);
+        } else if (proposalType == ArbitrationType.RELEASE) {
+            _release(escrowId, amount);
+        }
+    }
     
 
     //TODO: no longer necessary?

--- a/src/interfaces/IArbitrationModule.sol
+++ b/src/interfaces/IArbitrationModule.sol
@@ -25,13 +25,14 @@ struct ArbitrationProposal {
     uint256 amount;
     uint8 votesFor;
     uint8 votesAgainst;
+    bool autoExecute;
 }
 
 interface IArbitrationModule
 {
     function getProposal(bytes32 proposalId) external view returns (ArbitrationProposal memory); 
 
-    function proposeArbitration(IPolyEscrow polyEscrow, bytes32 escrowId, ArbitrationType proposalType, uint256 amount) external;
+    function proposeArbitration(IPolyEscrow polyEscrow, bytes32 escrowId, ArbitrationType proposalType, uint256 amount, bool autoExecute) external;
 
     function voteArbitration(IPolyEscrow polyEscrow, bytes32 proposalId, bool vote) external;
 

--- a/src/interfaces/IPolyEscrow.sol
+++ b/src/interfaces/IPolyEscrow.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "../interfaces/ISecurityContext.sol";
+import "../interfaces/IArbitrationModule.sol";
 import "../Types.sol";
 
 interface IPolyEscrow {
     function getSecurityContext() external view returns (ISecurityContext);
     function getEscrow(bytes32 escrowId) external view returns (Escrow memory);
     function placePayment(PaymentInput calldata paymentInput) external payable;
+    function executeArbitrationProposal(bytes32 escrowId, ArbitrationType proposalType, uint256 amount) external;
 }

--- a/test-foundry/AutoExecuteTest.t.sol
+++ b/test-foundry/AutoExecuteTest.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import {ArbitrationModule} from "../src/ArbitrationModule.sol";
+import {PolyEscrow, CreateEscrowInput, PaymentInput} from "../src/PolyEscrow.sol";
+import {SecurityContext} from "../src/SecurityContext.sol";
+import {SystemSettings} from "../src/SystemSettings.sol";
+import {ArbitrationType, ArbitrationStatus} from "../src/interfaces/IArbitrationModule.sol";
+import {ISecurityContext} from "../src/interfaces/ISecurityContext.sol";
+
+contract AutoExecuteTest is Test {
+    ArbitrationModule internal arbitrationModule;
+    PolyEscrow internal polyEscrow;
+    SecurityContext internal securityContext;
+    SystemSettings internal systemSettings;
+    
+    address internal admin = address(0x1);
+    address internal payer = address(0x2);
+    address internal receiver = address(0x3);
+    address internal arbiter = address(0x4);
+    address internal vaultAddress = address(0x5);
+    
+    bytes32 internal escrowId = bytes32("test-escrow");
+    
+    function setUp() public {
+        vm.startPrank(admin);
+        
+        securityContext = new SecurityContext(admin);
+        systemSettings = new SystemSettings(
+            ISecurityContext(securityContext),
+            vaultAddress,
+            0
+        );
+        
+        arbitrationModule = new ArbitrationModule();
+        polyEscrow = new PolyEscrow(ISecurityContext(securityContext), systemSettings, arbitrationModule);
+        
+        address[] memory arbiters = new address[](1);
+        arbiters[0] = arbiter;
+        
+        CreateEscrowInput memory input = CreateEscrowInput({
+            id: escrowId,
+            payer: payer,
+            receiver: receiver,
+            arbiters: arbiters,
+            arbitersRequired: 1,
+            amount: 1000,
+            currency: address(0),
+            startTime: block.timestamp,
+            endTime: block.timestamp + 86400,
+            arbitrationModule: arbitrationModule
+        });
+        
+        polyEscrow.createEscrow(input);
+        vm.stopPrank();
+        
+        vm.deal(payer, 1 ether);
+        vm.prank(payer);
+        polyEscrow.placePayment{value: 1000}(PaymentInput({
+            escrowId: escrowId,
+            currency: address(0),
+            amount: 1000
+        }));
+    }
+    
+    function testAutoExecuteFalse() public {
+        vm.recordLogs();
+        vm.prank(payer);
+        arbitrationModule.proposeArbitration(polyEscrow, escrowId, ArbitrationType.REFUND, 500, false);
+        
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 proposalId = entries[0].topics[1];
+        
+        vm.prank(arbiter);
+        arbitrationModule.voteArbitration(polyEscrow, proposalId, true);
+        
+        assertEq(uint(arbitrationModule.getProposal(proposalId).status), uint(ArbitrationStatus.ACCEPTED));
+        assertFalse(arbitrationModule.getProposal(proposalId).autoExecute);
+    }
+    
+    function testAutoExecuteTrue() public {
+        vm.recordLogs();
+        vm.prank(payer);
+        arbitrationModule.proposeArbitration(polyEscrow, escrowId, ArbitrationType.REFUND, 500, true);
+        
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        bytes32 proposalId = entries[0].topics[1];
+        
+        vm.prank(arbiter);
+        arbitrationModule.voteArbitration(polyEscrow, proposalId, true);
+        
+        assertEq(uint(arbitrationModule.getProposal(proposalId).status), uint(ArbitrationStatus.EXECUTED));
+        assertTrue(arbitrationModule.getProposal(proposalId).autoExecute);
+    }
+}

--- a/test-foundry/PolyEscrowTest.t.sol
+++ b/test-foundry/PolyEscrowTest.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import {PolyEscrow, PaymentInput} from "../src/PolyEscrow.sol";
 import {SecurityContext} from "../src/SecurityContext.sol";
 import {SystemSettings} from "../src/SystemSettings.sol";
+import {ArbitrationModule} from "../src/ArbitrationModule.sol";
 import {TestToken} from "../src/test-contracts/TestToken.sol";
 import {ISecurityContext} from "../src/interfaces/ISecurityContext.sol";
 import {console} from "forge-std/console.sol";
@@ -13,6 +14,7 @@ import {FailingToken} from "../src/test-contracts/FailingToken.sol";
 contract PaymentEscrowTest is Test {
     SecurityContext internal securityContext;
     SystemSettings internal systemSettings;
+    ArbitrationModule internal arbitrationModule;
     PolyEscrow internal escrow;
     TestToken internal testToken;
 
@@ -76,7 +78,8 @@ contract PaymentEscrowTest is Test {
         );
         
         testToken = new TestToken("XYZ", "ZYX");
-        escrow = new PolyEscrow(ISecurityContext(securityContext), systemSettings);
+        arbitrationModule = new ArbitrationModule();
+        escrow = new PolyEscrow(ISecurityContext(securityContext), systemSettings, arbitrationModule);
 
         testToken.mint(nonOwner, 10_000_000_000);
         testToken.mint(payer1, 10_000_000_000);

--- a/test/Arbitration.ts
+++ b/test/Arbitration.ts
@@ -119,11 +119,12 @@ describe('Arbitration', function () {
         proposerAccount: HardhatEthersSigner,
         escrowId: string,
         proposalType: number,
-        amount: number
+        amount: number,
+        autoExecute: boolean = false
     ): Promise<IArbitrationProposal> {
         const tx = await arbitrationModule
             .connect(proposerAccount)
-            .proposeArbitration(polyEscrow, escrowId, proposalType, amount);
+            .proposeArbitration(polyEscrow, escrowId, proposalType, amount, autoExecute);
 
         //capture the event, and the id from it
         const receipt = await tx.wait();
@@ -416,7 +417,8 @@ describe('Arbitration', function () {
                             polyEscrow,
                             escrowId,
                             PROPOSE_REFUND,
-                            1
+                            1,
+                            false
                         )
                 ).to.be.revertedWith('Unauthorized');
             }
@@ -441,7 +443,8 @@ describe('Arbitration', function () {
                             polyEscrow,
                             escrowId,
                             PROPOSE_REFUND,
-                            1
+                            1,
+                            false
                         )
                 ).to.be.revertedWith('InvalidEscrow');
             });
@@ -473,7 +476,8 @@ describe('Arbitration', function () {
                             polyEscrow,
                             escrowId,
                             PROPOSE_REFUND,
-                            1
+                            1,
+                            false
                         )
                 ).to.be.revertedWith('InvalidProposalNoArbiters');
             });
@@ -507,7 +511,8 @@ describe('Arbitration', function () {
                             polyEscrow,
                             escrowId,
                             PROPOSE_REFUND,
-                            1
+                            1,
+                            false
                         )
                 ).to.be.revertedWith('InvalidEscrowState');
             });
@@ -539,7 +544,8 @@ describe('Arbitration', function () {
                             polyEscrow,
                             escrowId,
                             PROPOSE_REFUND,
-                            amount + 1
+                            amount + 1,
+                            false
                         )
                 ).to.be.revertedWith('InvalidProposalAmount');
 
@@ -551,7 +557,8 @@ describe('Arbitration', function () {
                             polyEscrow,
                             escrowId,
                             PROPOSE_RELEASE,
-                            amount + 1
+                            amount + 1,
+                            false
                         )
                 ).to.be.revertedWith('InvalidProposalAmount');
             });
@@ -586,7 +593,8 @@ describe('Arbitration', function () {
                             polyEscrow,
                             escrowId,
                             proposalType,
-                            amount
+                            amount,
+                            false
                         )
                 )
                     .to.emit(arbitrationModule, 'ArbitrationProposed')


### PR DESCRIPTION
**Motivation**

In the new arbitration logic, the lifecycle of arbitration goes like this: 
Proposal 
A buyer or seller submits a proposal to either refund (to payer) or release (to receiver) a specific amount. At that point, it’s just a proposal.
Voting 
Arbiters (those who are registered as arbiters for the escrow) vote on the proposal. When it reaches a certain number of ‘yes’ votes, it’s automatically set to “ACCEPTED” status. But it isn’t executed at that point. 
Execution
Anyone can execute a proposal, IF it’s been accepted (if it’s status is ACCEPTED, that is). But it’s a separate step… if nobody calls the execute method on the arbitration module, then the effect of the accepted proposal never takes effect.  

**Changes:**

  1. Add autoExecute boolean property to ArbitrationProposal struct
  2. Update proposeArbitration() function to accept autoExecute parameter
  3. Implement auto-execution logic in voteArbitration() when proposal becomes ACCEPTED
  4. Add executeArbitrationProposal() method to PolyEscrow for ArbitrationModule to call
  5. Update all existing test calls to include new autoExecute parameter

  **Test:**

  1. testAutoExecuteFalse() - Verifies proposals with autoExecute=false become ACCEPTED but don't auto-execute
  2. testAutoExecuteTrue() - Verifies proposals with autoExecute=true automatically execute when ACCEPTED
  3.  Run forge test --match-contract AutoExecuteTest to verify both behaviors work correctly.