### PR TITLE
HAMSTR-819 : Escrow: Limit number of open (active) arbitration cases

### DIFF
--- a/src/ArbitrationModule.sol
+++ b/src/ArbitrationModule.sol
@@ -16,9 +16,12 @@ import "./interfaces/IArbitrationModule.sol";
  */
 contract ArbitrationModule is IArbitrationModule
 {
+    uint8 public constant MAX_ARBITRATION_CASES = 10;
+    
     mapping(bytes32 => ArbitrationProposal) private proposals;
     mapping(bytes32 => mapping(address => bool)) proposalVotes;
     uint8 public proposalCount;
+    uint8 public activeProposalCount;
 
     //EVENTS 
     event ArbitrationProposed (
@@ -62,7 +65,8 @@ contract ArbitrationModule is IArbitrationModule
 
         require(_escrowStateIsValid(polyEscrow, escrowId), "InvalidEscrowState");
 
-        //TODO: should there be a limit on number of open arbitration cases?
+        // Check if maximum number of active arbitration cases has been reached
+        require(activeProposalCount < MAX_ARBITRATION_CASES, "MaxArbitrationCasesReached");
 
         //TODO: ensure that escrow is in correct state to be arbitrated
         
@@ -81,6 +85,10 @@ contract ArbitrationModule is IArbitrationModule
         //record proposer as an automatic yes vote
         proposals[propId].votesFor = 1;
         proposalVotes[propId][msg.sender] = true;
+
+        // Increment counters
+        proposalCount++;
+        activeProposalCount++;
 
         //raise event 
         emit ArbitrationProposed(proposals[propId].id, proposals[propId].escrowId, msg.sender);
@@ -126,10 +134,14 @@ contract ArbitrationModule is IArbitrationModule
             // Auto-execute if autoExecute flag is true
             if (proposal.autoExecute) {
                 _executeArbitration(polyEscrow, proposal);
+            } else {
+                // If not auto-executing, decrement active count since proposal is no longer ACTIVE
+                activeProposalCount--;
             }
         }
         else if (proposal.votesAgainst >= (arbiterCount - arbitersRequired)) {
             proposal.status = ArbitrationStatus.REJECTED;
+            activeProposalCount--;
         }
 
         //raise event 
@@ -147,8 +159,10 @@ contract ArbitrationModule is IArbitrationModule
         require(proposal.id != bytes32(0), "InvalidProposal");
 
         //TODO: can only cancel if status is ACTIVE
+        require(proposal.status == ArbitrationStatus.ACTIVE, "InvalidProposalState");
 
         proposal.status = ArbitrationStatus.CANCELED;
+        activeProposalCount--;
     }
 
     function executeArbitration(IPolyEscrow polyEscrow, bytes32 proposalId) external virtual {
@@ -201,6 +215,7 @@ contract ArbitrationModule is IArbitrationModule
     function _executeArbitration(IPolyEscrow polyEscrow, ArbitrationProposal storage proposal) internal {
         polyEscrow.executeArbitrationProposal(proposal.escrowId, proposal.proposalType, proposal.amount);
         proposal.status = ArbitrationStatus.EXECUTED;
+        activeProposalCount--;
         emit ProposalExecuted(proposal.id, proposal.escrowId, msg.sender);
     }
 


### PR DESCRIPTION
**Motivation**

In the new arbitration logic, the lifecycle of arbitration goes like this: 

Proposal 
A buyer or seller submits a proposal to either refund (to payer) or release (to receiver) a specific amount. At that point, it’s just a proposal.

Voting 
Arbiters (those who are registered as arbiters for the escrow) vote on the proposal. When it reaches a certain number of ‘yes’ votes, it’s automatically set to “ACCEPTED” status. But it isn’t necessarily executed at that point. 

Execution
Anyone can execute a proposal, IF it’s been accepted (if it’s status is ACCEPTED, that is, and if it still meets other criteria of still being relevant). 

Currently, there is no limit on the number of arbitration cases that can be opened at once. There should be a limit, defined as a constant in ArbitrationModule.sol. 


**Changes:**

  1. Added MAX_ARBITRATION_CASES = 10 constant to limit concurrent arbitration cases
  2. Added activeProposalCount tracking for active proposals
  3. Implemented limit check in proposeArbitration() to enforce max cases
  4. Fixed proposalCount increment for unique proposal ID generation
  5. Added counter management for all proposal state transitions (EXECUTED, REJECTED, CANCELED)

